### PR TITLE
Add FGA export button to battle recorder

### DIFF
--- a/lib/app/battle/models/battle.dart
+++ b/lib/app/battle/models/battle.dart
@@ -45,7 +45,9 @@ class BattleRuntime {
     required this.region,
     required this.originalOptions,
     required this.originalQuest,
-  });
+  }) {
+    battleData.runtime = this;
+  }
 
   BattleShareData getShareData({bool allowNotWin = false, bool isCritTeam = false, bool includeReplayData = true}) {
     assert(battleData.isBattleWin || allowNotWin);
@@ -82,6 +84,7 @@ class BattleData {
   BattleDelegate? delegate;
   BattleReplayDelegateData replayDataRecord = BattleReplayDelegateData();
   BattleOptionsRuntime options = BattleOptionsRuntime();
+  BattleRuntime? runtime;
   final BattleLogger battleLogger = BattleLogger();
   BuildContext? context;
 


### PR DESCRIPTION
## Summary
- add an export button in the battle recorder to share runs with FGA
- enable the button only when runtime data is present and actions exist
- attach battle runtime to its battle data so the exporter can build share data

## Testing
- not run (flutter command unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68c86cc7e54c8333802a89ac3ca6e150