### PR TITLE
Ensure FGA export respects NP placement assumptions

### DIFF
--- a/test/utils/fga_export_test.dart
+++ b/test/utils/fga_export_test.dart
@@ -95,5 +95,27 @@ void main() {
         contains('at most two cards before an NP'),
       );
     });
+
+    test('NP later in the turn after too many normals is rejected', () {
+      final data = _shareDataWithAttacks([
+        [
+          _normalCard(),
+          _npCard(0),
+          _normalCard(cardType: CardType.quick),
+          _normalCard(cardType: CardType.arts),
+          _npCard(1),
+        ],
+      ]);
+      final warnings = <String>[];
+
+      final command = toFgaAutoSkillCommand(data, warnings: warnings);
+
+      expect(command, '0');
+      expect(warnings, hasLength(1));
+      expect(
+        warnings.single,
+        contains('at most two cards before an NP'),
+      );
+    });
   });
 }


### PR DESCRIPTION
## Summary
- document the NP placement assumptions in the FGA export helper and enforce them while keeping NP sets ordered by field slot
- expand the FGA export tests to cover single- and multi-NP turns, no-NP turns, and late NP warnings

## Testing
- flutter test test/utils/fga_export_test.dart *(fails: flutter not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c88d40d3848333830a5858edbb9036