### PR TITLE
Add BattleShareData fixtures and integration tests

### DIFF
--- a/test/data/battle_share_double_np.json
+++ b/test/data/battle_share_double_np.json
@@ -1,0 +1,104 @@
+{
+  "name": "Double NP door farm",
+  "share": {
+    "quest": {
+      "id": 9104010,
+      "phase": 1,
+      "enemyHash": "abc123",
+      "region": "na"
+    },
+    "team": {
+      "name": "Door Farming",
+      "mysticCode": {
+        "mysticCodeId": 9700010,
+        "level": 10
+      },
+      "onFieldSvts": [
+        {
+          "svtId": 100100,
+          "skillLvs": [10, 10, 10],
+          "tdLv": 5,
+          "lv": 90,
+          "ceId": 9400350,
+          "ceLimitBreak": true,
+          "ceLv": 100
+        },
+        {
+          "svtId": 100200,
+          "skillLvs": [10, 10, 10],
+          "tdLv": 5,
+          "lv": 90
+        },
+        {
+          "svtId": 100300,
+          "skillLvs": [10, 10, 10],
+          "tdLv": 5,
+          "lv": 90
+        }
+      ],
+      "backupSvts": []
+    },
+    "actions": [
+      {
+        "type": "skill",
+        "svt": 0,
+        "skill": 0
+      },
+      {
+        "type": "skill",
+        "skill": 2
+      },
+      {
+        "type": "attack",
+        "attacks": [
+          {
+            "svt": 0,
+            "isTD": true,
+            "cardType": "arts"
+          }
+        ]
+      },
+      {
+        "type": "base"
+      },
+      {
+        "type": "skill",
+        "svt": 1,
+        "skill": 2,
+        "options": {
+          "enemyTarget": 2
+        }
+      },
+      {
+        "type": "attack",
+        "attacks": [
+          {
+            "svt": 1,
+            "isTD": true,
+            "cardType": "arts"
+          },
+          {
+            "svt": 2,
+            "isTD": true,
+            "cardType": "arts"
+          }
+        ]
+      }
+    ]
+  },
+  "expected": {
+    "autoskill_cmd": "a4,#,t3f56",
+    "fields": {
+      "autoskill_name": "Door Farming",
+      "battle_config_server": "En",
+      "shuffle_cards": "None",
+      "support_mode": "Preferred",
+      "use_servant_priority": false
+    },
+    "notes_contains": [
+      "Imported from Chaldea",
+      "Quest 9104010/1 (NA)",
+      "Enemy hash abc123"
+    ]
+  }
+}

--- a/test/data/battle_share_np_warning.json
+++ b/test/data/battle_share_np_warning.json
@@ -1,0 +1,50 @@
+{
+  "name": "NP after too many normals",
+  "share": {
+    "quest": null,
+    "team": {
+      "name": "   ",
+      "onFieldSvts": [],
+      "backupSvts": []
+    },
+    "actions": [
+      {
+        "type": "attack",
+        "attacks": [
+          {
+            "svt": 0,
+            "isTD": false,
+            "cardType": "quick"
+          },
+          {
+            "svt": 0,
+            "isTD": false,
+            "cardType": "arts"
+          },
+          {
+            "svt": 0,
+            "isTD": false,
+            "cardType": "buster"
+          },
+          {
+            "svt": 0,
+            "isTD": true,
+            "cardType": "arts"
+          }
+        ]
+      }
+    ]
+  },
+  "expected": {
+    "autoskill_cmd": "0",
+    "fields": {
+      "autoskill_name": "--",
+      "battle_config_server": ""
+    },
+    "notes_contains": [
+      "Imported from Chaldea",
+      "Warnings:",
+      "Encountered an NP after 3 normal cards"
+    ]
+  }
+}

--- a/test/data/battle_share_order_change.json
+++ b/test/data/battle_share_order_change.json
@@ -1,0 +1,67 @@
+{
+  "name": "Order change setup",
+  "share": {
+    "quest": {
+      "id": 9401002,
+      "phase": 3,
+      "enemyHash": "orderchange",
+      "region": "jp"
+    },
+    "team": {
+      "name": "Order Change Setup",
+      "onFieldSvts": [
+        {
+          "svtId": 100500,
+          "skillLvs": [10, 10, 10]
+        },
+        {
+          "svtId": 100600,
+          "skillLvs": [10, 10, 10]
+        },
+        {
+          "svtId": 100700,
+          "skillLvs": [10, 10, 10]
+        }
+      ],
+      "backupSvts": [
+        {
+          "svtId": 100800,
+          "skillLvs": [9, 9, 9]
+        }
+      ]
+    },
+    "delegate": {
+      "replaceMemberIndexes": [
+        [0, 2]
+      ]
+    },
+    "actions": [
+      {
+        "type": "skill",
+        "skill": 1
+      },
+      {
+        "type": "attack",
+        "attacks": [
+          {
+            "svt": 2,
+            "isTD": true,
+            "cardType": "arts"
+          }
+        ]
+      }
+    ]
+  },
+  "expected": {
+    "autoskill_cmd": "kx136",
+    "fields": {
+      "autoskill_name": "Order Change Setup",
+      "battle_config_server": "Jp"
+    },
+    "notes_contains": [
+      "Imported from Chaldea",
+      "Quest 9401002/3 (JP)",
+      "Enemy hash orderchange"
+    ]
+  }
+}

--- a/test/utils/fga_export_test.dart
+++ b/test/utils/fga_export_test.dart
@@ -1,6 +1,10 @@
+import 'dart:convert';
+import 'dart:io';
+
 import 'package:chaldea/models/gamedata/common.dart';
 import 'package:chaldea/models/userdata/battle.dart';
 import 'package:chaldea/utils/fga_export.dart';
+import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
 BattleShareData _shareDataWithAttacks(List<List<BattleAttackRecordData>> turns) {
@@ -27,6 +31,70 @@ BattleAttackRecordData _npCard(int svt) {
     isTD: true,
     cardType: CardType.arts,
   );
+}
+
+class _BattleConfigFixture {
+  _BattleConfigFixture({
+    required this.path,
+    required this.name,
+    required this.data,
+    required this.expectedCommand,
+    required this.expectedFields,
+    required this.expectedNotesContains,
+    this.expectedNotes,
+  });
+
+  factory _BattleConfigFixture.fromFile(File file) {
+    final raw = jsonDecode(file.readAsStringSync()) as Map<String, dynamic>;
+    final shareJson = Map<String, dynamic>.from(raw['share'] as Map);
+    final expectedJson = Map<String, dynamic>.from(raw['expected'] as Map);
+    final fields = <String, dynamic>{};
+    final expectedFields = expectedJson['fields'];
+    if (expectedFields is Map) {
+      fields.addAll(Map<String, dynamic>.from(expectedFields));
+    }
+    final notesContains = expectedJson['notes_contains'];
+    final expectedNotesContains = notesContains is List
+        ? List<String>.from(notesContains)
+        : const <String>[];
+    final name = raw['name'] as String? ??
+        raw['description'] as String? ??
+        p.basenameWithoutExtension(file.path);
+
+    return _BattleConfigFixture(
+      path: file.path,
+      name: name,
+      data: BattleShareData.fromJson(shareJson),
+      expectedCommand: expectedJson['autoskill_cmd'] as String,
+      expectedFields: fields,
+      expectedNotesContains: expectedNotesContains,
+      expectedNotes: expectedJson['notes_equals'] as String?,
+    );
+  }
+
+  final String path;
+  final String name;
+  final BattleShareData data;
+  final String expectedCommand;
+  final Map<String, dynamic> expectedFields;
+  final List<String> expectedNotesContains;
+  final String? expectedNotes;
+}
+
+List<_BattleConfigFixture> _loadBattleConfigFixtures() {
+  final directory = Directory('test/data');
+  if (!directory.existsSync()) {
+    return const [];
+  }
+
+  final fixtures = directory
+      .listSync()
+      .whereType<File>()
+      .where((file) => file.path.endsWith('.json'))
+      .map(_BattleConfigFixture.fromFile)
+      .toList();
+  fixtures.sort((a, b) => a.name.compareTo(b.name));
+  return fixtures;
 }
 
 void main() {
@@ -117,5 +185,71 @@ void main() {
         contains('at most two cards before an NP'),
       );
     });
+  });
+
+  group('FGA battle config fixtures', () {
+    final fixtures = _loadBattleConfigFixtures();
+
+    test('fixtures are available', () {
+      expect(fixtures, isNotEmpty, reason: 'Battle config fixtures should exist.');
+    });
+
+    for (final fixture in fixtures) {
+      test(fixture.name, () {
+        final config = toFgaBattleConfig(fixture.data);
+
+        expect(
+          config['autoskill_cmd'],
+          fixture.expectedCommand,
+          reason: 'Fixture ${fixture.path} produced an unexpected AutoSkill command.',
+        );
+
+        fixture.expectedFields.forEach((key, value) {
+          expect(
+            config[key],
+            value,
+            reason: 'Fixture ${fixture.path} expected $key to equal $value.',
+          );
+        });
+
+        final notes = config['autoskill_notes'];
+        expect(notes, isA<String>(), reason: 'Fixture ${fixture.path} must set autoskill_notes.');
+        final notesString = notes as String;
+
+        if (fixture.expectedNotes != null) {
+          expect(
+            notesString,
+            fixture.expectedNotes,
+            reason: 'Fixture ${fixture.path} produced unexpected notes.',
+          );
+        }
+
+        for (final substring in fixture.expectedNotesContains) {
+          expect(
+            notesString,
+            contains(substring),
+            reason: 'Fixture ${fixture.path} notes should contain "$substring".',
+          );
+        }
+
+        final jsonConfig = Map<String, dynamic>.from(
+          jsonDecode(toFgaBattleConfigJson(fixture.data)) as Map,
+        );
+        expect(
+          jsonConfig['autoskill_cmd'],
+          fixture.expectedCommand,
+          reason: 'JSON output for ${fixture.path} produced an unexpected AutoSkill command.',
+        );
+        expect(jsonConfig['autoskill_notes'], notesString);
+
+        fixture.expectedFields.forEach((key, value) {
+          expect(
+            jsonConfig[key],
+            value,
+            reason: 'JSON output for ${fixture.path} expected $key to equal $value.',
+          );
+        });
+      });
+    }
   });
 }


### PR DESCRIPTION
## Summary
- add representative BattleShareData fixtures under test/data for export coverage
- extend fga_export_test to load the fixtures and verify the generated AutoSkill strings and JSON fields

## Testing
- flutter test test/utils/fga_export_test.dart *(fails: flutter command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c8a9ff3e2483339ca0ff338c1fee92