### PR TITLE
Validate mystic code before emitting order change token

### DIFF
--- a/test/data/battle_share_order_change.json
+++ b/test/data/battle_share_order_change.json
@@ -9,6 +9,10 @@
     },
     "team": {
       "name": "Order Change Setup",
+      "mysticCode": {
+        "mysticCodeId": 9700020,
+        "level": 10
+      },
       "onFieldSvts": [
         {
           "svtId": 100500,

--- a/test/utils/fga_export_test.dart
+++ b/test/utils/fga_export_test.dart
@@ -187,6 +187,29 @@ void main() {
     });
   });
 
+  group('FGA order change detection', () {
+    test('non-order-change mystic codes do not emit swap tokens', () {
+      final data = BattleShareData(
+        quest: null,
+        formation: BattleTeamFormation(
+          mysticCode: MysticCodeSaveData(mysticCodeId: 9700010, level: 10),
+        ),
+        delegate: BattleReplayDelegateData(
+          replaceMemberIndexes: [
+            [0, 1],
+          ],
+        ),
+        actions: [
+          BattleRecordData.skill(skill: 1),
+        ],
+      );
+
+      final command = toFgaAutoSkillCommand(data);
+
+      expect(command, 'k');
+    });
+  });
+
   group('FGA battle config fixtures', () {
     final fixtures = _loadBattleConfigFixtures();
 


### PR DESCRIPTION
## Summary
- gate order change token emission on mystic code ids that provide swap skills
- record the mystic code id for the order change fixture and add a regression test to ensure other mystic codes do not emit swap tokens

## Testing
- flutter test test/utils/fga_export_test.dart *(fails: Flutter SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c8ae4cb81483338fa73fae669ac105