### PR TITLE
Read FGA priorities from share data

### DIFF
--- a/lib/utils/fga_export.dart
+++ b/lib/utils/fga_export.dart
@@ -30,17 +30,20 @@ Map<String, dynamic> toFgaBattleConfig(BattleShareData data) {
     ],
   ].join('\n');
 
+  final cardPriority = _cardPriorityString(data);
+  final servantPriority = _servantPriorityString(data);
+
   return {
     'autoskill_name': (data.formation.name ?? '').trim().isEmpty ? '--' : data.formation.name,
     'autoskill_cmd': autoskillCommand,
     'autoskill_notes': autoskillNotes,
-    'card_priority': _kDefaultCardPriority,
+    'card_priority': cardPriority,
     'auto_skill_rearrange_cards': '',
     'auto_skill_brave_chains': '',
     'shuffle_cards': 'None',
     'shuffle_cards_wave': 3,
-    'use_servant_priority': false,
-    'servant_priority': _kDefaultServantPriority,
+    'use_servant_priority': servantPriority != null,
+    'servant_priority': servantPriority ?? _kDefaultServantPriority,
     'spam_x': _defaultSpamConfigJson,
     'autoskill_party': -1,
     'battle_config_mat': <String>{},
@@ -182,6 +185,36 @@ String? _enemyTargetToken(int target) {
     return null;
   }
   return 't${target + 1}';
+}
+
+String _cardPriorityString(BattleShareData data) {
+  final priority = data.fgaCardPriority ?? data.formation.fgaCardPriority;
+  if (priority == null || priority.isEmpty) {
+    return _kDefaultCardPriority;
+  }
+  final waves = priority
+      .map((wave) => wave.where((token) => token.isNotEmpty).join(', '))
+      .where((wave) => wave.isNotEmpty)
+      .toList();
+  if (waves.isEmpty) {
+    return _kDefaultCardPriority;
+  }
+  return waves.join('\n');
+}
+
+String? _servantPriorityString(BattleShareData data) {
+  final priority = data.fgaServantPriority ?? data.formation.fgaServantPriority;
+  if (priority == null || priority.isEmpty) {
+    return null;
+  }
+  final waves = priority
+      .map((wave) => wave.map((value) => value.toString()).join(','))
+      .where((wave) => wave.isNotEmpty)
+      .toList();
+  if (waves.isEmpty) {
+    return null;
+  }
+  return waves.join('\n');
 }
 
 String? _servantSkillToken(int svtIndex, int? skillIndex) {

--- a/test/data/battle_share_custom_priority.json
+++ b/test/data/battle_share_custom_priority.json
@@ -1,0 +1,30 @@
+{
+  "name": "Custom card and servant priority",
+  "share": {
+    "quest": null,
+    "cardPriority": [
+      ["WA", "WB", "WQ", "A", "B", "Q", "RA", "RB", "RQ"]
+    ],
+    "team": {
+      "name": "Priority Team",
+      "mysticCode": {},
+      "onFieldSvts": [null, null, null],
+      "backupSvts": [],
+      "servantPriority": [
+        [2, 1, 3, 4, 5, 6]
+      ]
+    },
+    "actions": []
+  },
+  "expected": {
+    "autoskill_cmd": "",
+    "fields": {
+      "card_priority": "WA, WB, WQ, A, B, Q, RA, RB, RQ",
+      "servant_priority": "2,1,3,4,5,6",
+      "use_servant_priority": true
+    },
+    "notes_contains": [
+      "Imported from Chaldea"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- preserve card and servant priority metadata on BattleShareData and BattleTeamFormation when reading or writing JSON
- use the stored priorities when building the FGA battle config so custom ordering propagates into the export
- add a fixture that verifies custom priorities are present in the serialized configuration

## Testing
- `flutter test test/utils/fga_export_test.dart` *(fails: flutter command unavailable in environment)*
- `dart test test/utils/fga_export_test.dart` *(fails: dart command unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8b35fefc88333a39772e405ad9ed5