### PR TITLE
Add complex FGA battle fixtures and tighten export tests

### DIFF
--- a/test/data/battle_share_multi_wave.json
+++ b/test/data/battle_share_multi_wave.json
@@ -1,0 +1,143 @@
+{
+  "name": "Three-wave mixed NP setup",
+  "share": {
+    "quest": {
+      "id": 9202001,
+      "phase": 2,
+      "enemyHash": "triplewave",
+      "region": "jp"
+    },
+    "team": {
+      "name": "Triple Wave",
+      "mysticCode": {
+        "mysticCodeId": 9700010,
+        "level": 10
+      },
+      "onFieldSvts": [
+        {
+          "svtId": 100100,
+          "skillLvs": [10, 10, 10],
+          "tdLv": 5,
+          "lv": 90
+        },
+        {
+          "svtId": 100200,
+          "skillLvs": [10, 10, 10],
+          "tdLv": 5,
+          "lv": 90
+        },
+        {
+          "svtId": 100300,
+          "skillLvs": [10, 10, 10],
+          "tdLv": 5,
+          "lv": 90
+        }
+      ],
+      "backupSvts": [
+        {
+          "svtId": 100400,
+          "skillLvs": [9, 9, 9]
+        }
+      ]
+    },
+    "actions": [
+      {
+        "type": "skill",
+        "svt": 0,
+        "skill": 0
+      },
+      {
+        "type": "attack",
+        "attacks": [
+          {
+            "svt": 0,
+            "isTD": true,
+            "cardType": "arts"
+          }
+        ]
+      },
+      {
+        "type": "base"
+      },
+      {
+        "type": "skill",
+        "svt": 1,
+        "skill": 2
+      },
+      {
+        "type": "skill",
+        "skill": 0
+      },
+      {
+        "type": "attack",
+        "attacks": [
+          {
+            "svt": 2,
+            "isTD": false,
+            "cardType": "buster"
+          },
+          {
+            "svt": 1,
+            "isTD": true,
+            "cardType": "arts"
+          }
+        ]
+      },
+      {
+        "type": "skill",
+        "svt": 2,
+        "skill": 0
+      },
+      {
+        "type": "attack",
+        "attacks": [
+          {
+            "svt": 2,
+            "isTD": true,
+            "cardType": "arts"
+          }
+        ]
+      },
+      {
+        "type": "base"
+      },
+      {
+        "type": "skill",
+        "svt": 0,
+        "skill": 2
+      },
+      {
+        "type": "skill",
+        "svt": 1,
+        "skill": 1
+      },
+      {
+        "type": "attack",
+        "attacks": [
+          {
+            "svt": 2,
+            "isTD": true,
+            "cardType": "arts"
+          },
+          {
+            "svt": 0,
+            "isTD": true,
+            "cardType": "arts"
+          }
+        ]
+      }
+    ]
+  },
+  "expected": {
+    "autoskill_cmd": "a4,#,fjn15,g6,#,ce46",
+    "fields": {
+      "autoskill_name": "Triple Wave",
+      "battle_config_server": "Jp"
+    },
+    "notes_contains": [
+      "Imported from Chaldea",
+      "Quest 9202001/2 (JP)",
+      "Enemy hash triplewave"
+    ]
+  }
+}

--- a/test/data/battle_share_multiple_order_change.json
+++ b/test/data/battle_share_multiple_order_change.json
@@ -1,0 +1,100 @@
+{
+  "name": "Back-to-back order changes",
+  "share": {
+    "quest": {
+      "id": 9402004,
+      "phase": 3,
+      "enemyHash": "doubleorder",
+      "region": "na"
+    },
+    "team": {
+      "name": "Swap Parade",
+      "mysticCode": {
+        "mysticCodeId": 9700020,
+        "level": 10
+      },
+      "onFieldSvts": [
+        {
+          "svtId": 100500,
+          "skillLvs": [10, 10, 10]
+        },
+        {
+          "svtId": 100600,
+          "skillLvs": [10, 10, 10]
+        },
+        {
+          "svtId": 100700,
+          "skillLvs": [10, 10, 10]
+        }
+      ],
+      "backupSvts": [
+        {
+          "svtId": 100800,
+          "skillLvs": [9, 9, 9]
+        },
+        {
+          "svtId": 100900,
+          "skillLvs": [9, 9, 9]
+        }
+      ]
+    },
+    "delegate": {
+      "replaceMemberIndexes": [
+        [0, 2],
+        [1, 0]
+      ]
+    },
+    "actions": [
+      {
+        "type": "skill",
+        "skill": 1
+      },
+      {
+        "type": "skill",
+        "svt": 0,
+        "skill": 0
+      },
+      {
+        "type": "attack",
+        "attacks": [
+          {
+            "svt": 0,
+            "isTD": true,
+            "cardType": "arts"
+          }
+        ]
+      },
+      {
+        "type": "skill",
+        "skill": 1
+      },
+      {
+        "type": "skill",
+        "svt": 1,
+        "skill": 2
+      },
+      {
+        "type": "attack",
+        "attacks": [
+          {
+            "svt": 1,
+            "isTD": true,
+            "cardType": "arts"
+          }
+        ]
+      }
+    ]
+  },
+  "expected": {
+    "autoskill_cmd": "kx134,kx21f5",
+    "fields": {
+      "autoskill_name": "Swap Parade",
+      "battle_config_server": "En"
+    },
+    "notes_contains": [
+      "Imported from Chaldea",
+      "Quest 9402004/3 (NA)",
+      "Enemy hash doubleorder"
+    ]
+  }
+}

--- a/test/data/battle_share_target_switches.json
+++ b/test/data/battle_share_target_switches.json
@@ -1,0 +1,110 @@
+{
+  "name": "Frequent target switches",
+  "share": {
+    "quest": {
+      "id": 9105007,
+      "phase": 1,
+      "enemyHash": "targetdance",
+      "region": "na"
+    },
+    "team": {
+      "name": "Target Dance",
+      "mysticCode": {
+        "mysticCodeId": 9700010,
+        "level": 10
+      },
+      "onFieldSvts": [
+        {
+          "svtId": 100100,
+          "skillLvs": [10, 10, 10]
+        },
+        {
+          "svtId": 100200,
+          "skillLvs": [10, 10, 10]
+        },
+        {
+          "svtId": 100300,
+          "skillLvs": [10, 10, 10]
+        }
+      ],
+      "backupSvts": []
+    },
+    "actions": [
+      {
+        "type": "skill",
+        "svt": 1,
+        "skill": 0,
+        "options": {
+          "enemyTarget": 1
+        }
+      },
+      {
+        "type": "skill",
+        "svt": 2,
+        "skill": 2,
+        "options": {
+          "enemyTarget": 2
+        }
+      },
+      {
+        "type": "skill",
+        "svt": 0,
+        "skill": 1,
+        "options": {
+          "enemyTarget": 0
+        }
+      },
+      {
+        "type": "attack",
+        "options": {
+          "enemyTarget": 2
+        },
+        "attacks": [
+          {
+            "svt": 2,
+            "isTD": false,
+            "cardType": "arts"
+          },
+          {
+            "svt": 1,
+            "isTD": true,
+            "cardType": "arts"
+          }
+        ]
+      },
+      {
+        "type": "skill",
+        "svt": 2,
+        "skill": 0,
+        "options": {
+          "enemyTarget": 0
+        }
+      },
+      {
+        "type": "attack",
+        "options": {
+          "enemyTarget": 1
+        },
+        "attacks": [
+          {
+            "svt": 2,
+            "isTD": true,
+            "cardType": "arts"
+          }
+        ]
+      }
+    ]
+  },
+  "expected": {
+    "autoskill_cmd": "t2dt3it1bt3n15,t1gt26",
+    "fields": {
+      "autoskill_name": "Target Dance",
+      "battle_config_server": "En"
+    },
+    "notes_contains": [
+      "Imported from Chaldea",
+      "Quest 9105007/1 (NA)",
+      "Enemy hash targetdance"
+    ]
+  }
+}

--- a/test/utils/fga_export_test.dart
+++ b/test/utils/fga_export_test.dart
@@ -219,6 +219,18 @@ void main() {
 
     for (final fixture in fixtures) {
       test(fixture.name, () {
+        final warnings = <String>[];
+        final command = toFgaAutoSkillCommand(
+          fixture.data,
+          warnings: warnings,
+        );
+
+        expect(
+          command,
+          fixture.expectedCommand,
+          reason: 'Fixture ${fixture.path} produced an unexpected AutoSkill command.',
+        );
+
         final config = toFgaBattleConfig(fixture.data);
 
         expect(
@@ -238,6 +250,27 @@ void main() {
         final notes = config['autoskill_notes'];
         expect(notes, isA<String>(), reason: 'Fixture ${fixture.path} must set autoskill_notes.');
         final notesString = notes as String;
+
+        if (warnings.isEmpty) {
+          expect(
+            notesString,
+            isNot(contains('Warnings:')),
+            reason: 'Fixture ${fixture.path} should not surface warnings.',
+          );
+        } else {
+          expect(
+            notesString,
+            contains('Warnings:'),
+            reason: 'Fixture ${fixture.path} did not record warnings in the notes.',
+          );
+          for (final warning in warnings) {
+            expect(
+              notesString,
+              contains(warning),
+              reason: 'Fixture ${fixture.path} notes should contain the warning "$warning".',
+            );
+          }
+        }
 
         if (fixture.expectedNotes != null) {
           expect(


### PR DESCRIPTION
## Summary
- add fixtures covering multi-wave clears, rapid target swaps, and consecutive order changes
- expand `fga_export_test.dart` to verify autoskill commands and warning propagation for each fixture

## Testing
- not run (flutter and dart unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68c8bcaaef28833391f68bf7607889af